### PR TITLE
Add Astro project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.astro
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# codex_test
+# Astro Portfolio
+
+Estructura inicial para un portafolio personal construido con [Astro](https://astro.build/).
+
+## Scripts
+- `npm install` instala las dependencias.
+
+- `npm run dev` inicia el servidor de desarrollo.
+- `npm run build` genera la versión estática del sitio.
+
+La navegación se define de forma automática a partir de los archivos dentro de `src/pages`.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  site: 'https://example.com',
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "astro-portfolio",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build"
+  },
+  "dependencies": {
+    "astro": "latest"
+  }
+}

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,0 +1,9 @@
+---
+const { imageUrl, title, description } = Astro.props;
+// Componente de tarjeta reutilizable
+---
+<article style="border:1px solid #ddd; padding:1rem; border-radius:8px; max-width:300px;">
+  {imageUrl && <img src={imageUrl} alt={title} style="width:100%; border-radius:4px;" />}
+  <h3>{title}</h3>
+  <p>{description}</p>
+</article>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -1,0 +1,40 @@
+---
+const year = new Date().getFullYear();
+// Layout principal con header, contenido y footer compartido
+---
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><slot name="title">Mi Portafolio</slot></title>
+  </head>
+  <body>
+    <header style="display:flex; justify-content:space-between; align-items:center; padding:1rem 2rem; border-bottom:1px solid #ddd;">
+      <div class="logo">
+        <!-- Espacio para el logo -->
+        <slot name="logo" />
+      </div>
+      <nav>
+        <ul style="display:flex; gap:1rem; list-style:none; margin:0; padding:0;">
+          <li><a href="/">Inicio</a></li>
+          <li><a href="/portafolio">Portafolio</a></li>
+          <li><a href="/proyectos">Proyectos</a></li>
+          <li><a href="/blog">Blog</a></li>
+          <li><a href="/sobre-mi">Sobre Mí</a></li>
+          <li><a href="/contacto">Contacto</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main style="padding:2rem;">
+      <slot />
+    </main>
+    <footer style="text-align:center; padding:1rem 0; border-top:1px solid #ddd;">
+      <p>&copy; <span id="year">{year}</span> Mi Portafolio</p>
+      <div class="social">
+        <!-- Enlaces a iconos de redes sociales -->
+        <slot name="social" />
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,0 +1,6 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+<MainLayout>
+  <h1>Blog</h1>
+</MainLayout>

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -1,0 +1,6 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+<MainLayout>
+  <h1>Contacto</h1>
+</MainLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,6 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+<MainLayout>
+  <h1>Inicio</h1>
+</MainLayout>

--- a/src/pages/portafolio.astro
+++ b/src/pages/portafolio.astro
@@ -1,0 +1,6 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+<MainLayout>
+  <h1>Portafolio</h1>
+</MainLayout>

--- a/src/pages/proyectos.astro
+++ b/src/pages/proyectos.astro
@@ -1,0 +1,6 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+<MainLayout>
+  <h1>Proyectos</h1>
+</MainLayout>

--- a/src/pages/sobre-mi.astro
+++ b/src/pages/sobre-mi.astro
@@ -1,0 +1,6 @@
+---
+import MainLayout from '../layouts/MainLayout.astro';
+---
+<MainLayout>
+  <h1>Sobre Mí</h1>
+</MainLayout>


### PR DESCRIPTION
## Summary
- initialize Astro project configuration
- add main layout with header and footer
- create reusable `Card` component
- add placeholder pages for navigation sections
- update README with instructions
- fix gitignore and install dependencies

## Testing
- `node -v`
- `npm install`
- `npm run build`
- `npm run dev -h`


------
https://chatgpt.com/codex/tasks/task_e_684497e3bad08326af2a06b0b5b13dfb